### PR TITLE
added `react` as peer dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "prepare": "yarn build",
     "release": "release-it"
   },
+  "peerDependencies": {
+    "react": ">=16.8"
+  },
   "devDependencies": {
     "@commitlint/config-conventional": "^12.1.4",
     "@release-it/conventional-changelog": "^3.0.1",


### PR DESCRIPTION
This dependency uses `react` as dependency and therefore should declare it inside `peerDependencies`. It works now on more forgetful `npm` and `yarn 1` package managers, but has issues while using `pnpm` and therefore cause issues to using `react-navigation`.