### PR TITLE
feat: support passing undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,9 @@ const useIsomorphicLayoutEffect =
 /**
  * React hook which returns the latest callback without changing the reference.
  */
-export default function useLatestCallback<T extends Function>(callback: T): T {
+export default function useLatestCallback<T extends Function | undefined>(
+  callback: T
+): T {
   const ref = React.useRef<T>(callback);
 
   const latestCallback = React.useRef(function latestCallback(
@@ -14,7 +16,7 @@ export default function useLatestCallback<T extends Function>(callback: T): T {
     ...args: unknown[]
   ) {
     // eslint-disable-next-line babel/no-invalid-this
-    return ref.current.apply(this, args);
+    return ref.current?.apply(this, args);
   } as unknown as T).current;
 
   useIsomorphicLayoutEffect(() => {


### PR DESCRIPTION
Goal of this PR is to allow passing `undefined` as callback when it's optional.

Useful for memoizing values when callback passed through props is optional: 

Instead of: 

```ts
const renderLabelLatest = useLatestCallback(
    renderLabel ? renderLabel : () => {}
  );
``` 
We can do this

```ts
const renderLabelLatest = useLatestCallback(renderLabel);
``` 