### PR TITLE
fix - ensure correct `useIsomorphicLayoutEffect` detection in React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
   "eslintIgnore": [
     "node_modules/",
     "lib/"
-  ]
+  ],
+  "dependencies": {
+    "use-isomorphic-layout-effect": "^1.1.2"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
-
-const useIsomorphicLayoutEffect =
-  typeof document !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
 
 /**
  * React hook which returns the latest callback without changing the reference.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4597,6 +4597,11 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
+use-isomorphic-layout-effect@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
+  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
+
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"


### PR DESCRIPTION
RE: https://github.com/satya164/use-latest-callback/issues/3

Ensure `useIsomorphicLayoutEffect` correctly detected in React Native environment, by using `use-isomorphic-layout-effect` library that supports this hook instead of rolling our own.