### PR TITLE
fix: import error when use it in react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "source": "./src/index.ts",
   "main": "./lib/src/index.js",
   "types": "./lib/src/index.d.ts",
+  "react-native": "./src/index.ts",
   "exports": {
     ".": {
       "types": "./lib/src/index.d.ts",


### PR DESCRIPTION
When I use react native navigation, an import error will appear. I hope it can be imported from src normally.
<img width="1252" src="https://github.com/satya164/use-latest-callback/assets/19701675/e5cecfd2-f138-458c-993f-764289f689b3">
<img width="1862" alt="image" src="https://github.com/satya164/use-latest-callback/assets/19701675/75dba5ef-7a44-4d73-a45c-b9c47d9b0db0">


