### PR TITLE
Rework how cjs and esm are supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 
+### [0.2.1](https://github.com/satya164/use-latest-callback/compare/v0.2.0...v0.2.1) (2024-07-10)
+
 ## [0.2.0](https://github.com/satya164/use-latest-callback/compare/v0.1.11...v0.2.0) (2024-07-10)
 
 

--- a/esm.mjs
+++ b/esm.mjs
@@ -1,6 +1,0 @@
-// eslint-disable-next-line import/extensions
-import exports from './lib/src/index.js';
-
-const useLatestCallback = exports.default;
-
-export default useLatestCallback;

--- a/package.json
+++ b/package.json
@@ -13,27 +13,29 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "type": "commonjs",
+  "type": "module",
   "source": "./src/index.ts",
-  "main": "./lib/src/index.js",
-  "types": "./lib/src/index.d.ts",
+  "main": "./lib/cjs/src/index.js",
+  "module": "./lib/esm/src/index.js",
+  "types": "./lib/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./lib/src/index.d.ts",
-      "import": "./esm.mjs",
-      "require": "./lib/src/index.js"
+      "types": "./lib/types/src/index.d.ts",
+      "import": "./lib/esm/src/index.js",
+      "require": "./lib/cjs/src/index.js"
     }
   },
   "files": [
     "src",
-    "lib",
-    "esm.mjs"
+    "lib"
   ],
   "scripts": {
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "typecheck": "tsc --noEmit",
     "prebuild": "del lib",
-    "build": "tsc --declaration",
+    "build:cjs": "tsc --project tsconfig.json",
+    "build:esm": "tsc --project tsconfig.esm.json",
+    "build": "yarn build:cjs && yarn build:esm",
     "prepare": "yarn build",
     "release": "release-it"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-latest-callback",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "React hook which returns the latest callback without changing the reference",
   "repository": "https://github.com/satya164/use-latest-callback",
   "author": "Satyajit Sahoo <satyajit.happy@gmail.com>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,4 +23,4 @@ function useLatestCallback<T extends Function>(callback: T): T {
 }
 
 // Use export assignment to compile to module.exports =
-export = useLatestCallback;
+export default useLatestCallback;

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib/esm",
+    "module": "ESNext",
+    "resolveJsonModule": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "lib",
+    "outDir": "lib/cjs",
+    "declarationDir": "lib/types",
     "target": "ES5",
-    "module": "NodeNext",
+    "module": "CommonJS",
     "declaration": true,
     "esModuleInterop": true,
     "allowUnreachableCode": false,
@@ -21,5 +22,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true
-  }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "lib", "esm"]
 }


### PR DESCRIPTION
The recent changes where the esm file imported the built cjs files is causing havoc with our build tooling (primarily around it incorrectly resolving default imports), generally it is more typical to output ESM and CJS build files separately which work a lot better with rollup/esbuild (we're using vite) and should prevent anyone else having issues with this either.

Thanks.